### PR TITLE
Update Makefile and manifests to reference correct image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.39.1
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= ghcr.io/innabox/cloudkit-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manager.yaml
+images:
+- name: controller
+  newName: ghcr.io/innabox/cloudkit-operator
+  newTag: latest


### PR DESCRIPTION
This updates the Makefile and the manifests in `config/manager` to
reference the image built by the `build-image` workflow. With these
changes, you can successfully deploy the operator by running:

    make deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default container image used in build and deployment processes to ensure consistency and alignment with our standardized image repository.
  - Adjusted deployment configuration to reflect the use of the officially supported image, streamlining the build and release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->