### PR TITLE
Run golangci-lint automatically

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,3 +12,18 @@ jobs:
       with:
         python-version: "3.13"
     - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: -c .pre-commit-config-ci.yaml
+
+  golangci-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,8 @@
 version: "2"
-
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
@@ -28,6 +11,7 @@ linters:
     - gocyclo
     - govet
     - ineffassign
+    - lll
     - misspell
     - nakedret
     - prealloc
@@ -36,14 +20,31 @@ linters:
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+  exclusions:
+    generated: lax
     rules:
-      - name: comment-spacings
-
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 formatters:
-  disable-all: true
   enable:
     - gofmt
     - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config-ci.yaml
+++ b/.pre-commit-config-ci.yaml
@@ -19,12 +19,3 @@ repos:
       files: \.(yaml|yml)$
       types: [file, yaml]
       entry: yamllint --strict
-
-- repo: local
-  hooks:
-  - id: golangci-lint
-    pass_filenames: false
-    name: golangci-lint
-    language: system
-    files: \.go$
-    entry: golangci-lint run


### PR DESCRIPTION
This runs golangci-lint via pre-commit locally, and via the official github action [1] in our pre-commit workflow.

[1]: https://github.com/golangci/golangci-lint-action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced our CI workflow with a new linting job for Go, ensuring more robust code quality checks.
  - Improved pre-commit configurations to enforce comprehensive validation, including checks for trailing whitespace, merge conflicts, and YAML correctness.
  - Streamlined formatter settings to clarify the structure for enabling and configuring checks for a more consistent development experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->