### PR TITLE
Teach controller how to create and manage resources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,10 @@ linters:
     revive:
       rules:
         - name: comment-spacings
+    staticcheck:
+      checks:
+      - all
+      - '-QF1008'
   exclusions:
     generated: lax
     rules:

--- a/api/v1alpha1/clusterorder_clusterreference.go
+++ b/api/v1alpha1/clusterorder_clusterreference.go
@@ -1,0 +1,55 @@
+package v1alpha1
+
+func (co *ClusterOrder) SetClusterReferenceNamespace(name string) {
+	co.EnsureClusterReference()
+	co.Status.ClusterReference.Namespace = name
+}
+
+func (co *ClusterOrder) SetClusterReferenceServiceAccountName(name string) {
+	co.EnsureClusterReference()
+	co.Status.ClusterReference.ServiceAccountName = name
+}
+
+func (co *ClusterOrder) SetClusterReferenceRoleBindingName(name string) {
+	co.EnsureClusterReference()
+	co.Status.ClusterReference.RoleBindingName = name
+}
+
+func (co *ClusterOrder) SetClusterReferenceHostedClusterName(name string) {
+	co.EnsureClusterReference()
+	co.Status.ClusterReference.HostedClusterName = name
+}
+
+func (co *ClusterOrder) EnsureClusterReference() {
+	if co.Status.ClusterReference == nil {
+		co.Status.ClusterReference = &ClusterOrderClusterReferenceType{}
+	}
+}
+
+func (co *ClusterOrder) GetClusterReferenceNamespace() string {
+	if co.Status.ClusterReference == nil {
+		return ""
+	}
+	return co.Status.ClusterReference.Namespace
+}
+
+func (co *ClusterOrder) GetClusterReferenceServiceAccountName() string {
+	if co.Status.ClusterReference == nil {
+		return ""
+	}
+	return co.Status.ClusterReference.ServiceAccountName
+}
+
+func (co *ClusterOrder) GetClusterReferenceRoleBindingName() string {
+	if co.Status.ClusterReference == nil {
+		return ""
+	}
+	return co.Status.ClusterReference.RoleBindingName
+}
+
+func (co *ClusterOrder) GetClusterReferenceHostedClusterName() string {
+	if co.Status.ClusterReference == nil {
+		return ""
+	}
+	return co.Status.ClusterReference.HostedClusterName
+}

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -76,6 +76,7 @@ type ClusterOrderClusterReferenceType struct {
 	Namespace          string `json:"namespace"`
 	HostedClusterName  string `json:"hostedClusterName"`
 	ServiceAccountName string `json:"serviceAccountName"`
+	RoleBindingName    string `json:"roleBindingName"`
 }
 
 // ClusterOrderStatus defines the observed state of ClusterOrder

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -59,11 +59,14 @@ spec:
                   namespace:
                     description: Namespace that contains the HostedCluster resource
                     type: string
+                  roleBindingName:
+                    type: string
                   serviceAccountName:
                     type: string
                 required:
                 - hostedClusterName
                 - namespace
+                - roleBindingName
                 - serviceAccountName
                 type: object
               conditions:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: ghcr.io/innabox/cloudkit-operator
-  newTag: latest
+  newName: cloudkit-operator
+  newTag: devel

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,19 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - cloudkit.openshift.io
   resources:
   - clusterorders
@@ -30,3 +43,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
+	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
 	sigs.k8s.io/controller-runtime v0.19.0
@@ -84,7 +85,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.31.0 // indirect
 	k8s.io/apiextensions-apiserver v0.31.0 // indirect
 	k8s.io/apiserver v0.31.0 // indirect
 	k8s.io/component-base v0.31.0 // indirect

--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -20,13 +20,44 @@ package controller
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cloudkitv1alpha1 "github.com/innabox/cloudkit-operator/api/v1alpha1"
 )
+
+// NewComponentFn is the type of a function that creates a required component
+type NewComponentFn func(context.Context, *cloudkitv1alpha1.ClusterOrder) (*appResource, error)
+
+type appResource struct {
+	object      client.Object
+	mutateFn    controllerutil.MutateFn
+	shouldExist bool
+}
+
+type component struct {
+	name string
+	fn   NewComponentFn
+}
+
+func (r *ClusterOrderReconciler) components() []component {
+	return []component{
+		{"Namespace", r.newNamespace},
+		{"ServiceAccount", r.newServiceAccount},
+		{"RoleBinding", r.newAdminRoleBinding},
+	}
+}
 
 // ClusterOrderReconciler reconciles a ClusterOrder object
 type ClusterOrderReconciler struct {
@@ -34,32 +65,191 @@ type ClusterOrderReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+func newClusterReference() *cloudkitv1alpha1.ClusterOrderClusterReferenceType {
+	return &cloudkitv1alpha1.ClusterOrderClusterReferenceType{}
+}
+
 // +kubebuilder:rbac:groups=cloudkit.openshift.io,resources=clusterorders,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cloudkit.openshift.io,resources=clusterorders/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cloudkit.openshift.io,resources=clusterorders/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ClusterOrder object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
-//
-//nolint:revive
 func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	_ = ctrllog.FromContext(ctx)
 
-	// TODO(user): your logic here
+	instance := &cloudkitv1alpha1.ClusterOrder{}
+	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
 
-	return ctrl.Result{}, nil
+	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.handleUpdate(ctx, req, instance)
+	} else {
+		return r.handleDelete(ctx, req, instance)
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterOrderReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	labelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			cloudkitClusterOrderNameLabel: "",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cloudkitv1alpha1.ClusterOrder{}).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.mapObjectToCluster),
+			builder.WithPredicates(labelPredicate),
+		).
+		Watches(
+			&corev1.ServiceAccount{},
+			handler.EnqueueRequestsFromMapFunc(r.mapObjectToCluster),
+			builder.WithPredicates(labelPredicate),
+		).
+		Watches(
+			&rbacv1.RoleBinding{},
+			handler.EnqueueRequestsFromMapFunc(r.mapObjectToCluster),
+			builder.WithPredicates(labelPredicate),
+		).
 		Complete(r)
+}
+
+func (r *ClusterOrderReconciler) mapObjectToCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+
+	clusterOrderName, exists := obj.GetLabels()[cloudkitClusterOrderNameLabel]
+	if !exists {
+		return nil
+	}
+
+	clusterOrderNamespace, exists := obj.GetLabels()[cloudkitClusterOrderNamespaceLabel]
+	if !exists {
+		return nil
+	}
+
+	log.Info("Selecting " + obj.GetName())
+
+	return []reconcile.Request{
+		{
+			NamespacedName: client.ObjectKey{
+				Name:      clusterOrderName,
+				Namespace: clusterOrderNamespace,
+			},
+		},
+	}
+}
+
+func (r *ClusterOrderReconciler) handleUpdate(ctx context.Context, _ ctrl.Request, instance *cloudkitv1alpha1.ClusterOrder) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+	log.Info("Create or update " + instance.GetName())
+
+	// Do we have a finalizer yet?
+	if !controllerutil.ContainsFinalizer(instance, cloudkitFinalizer) {
+		controllerutil.AddFinalizer(instance, cloudkitFinalizer)
+		if err := r.Update(ctx, instance); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Do we have a clusterReference yet?
+	if instance.Status.ClusterReference == nil {
+		log.Info("Adding cluster reference")
+		instance.Status.ClusterReference = newClusterReference()
+		if err := r.Status().Update(ctx, instance); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	for _, component := range r.components() {
+		log.Info("Handling component " + component.name)
+
+		resource, err := component.fn(ctx, instance)
+		if err != nil {
+			log.Error(err, "Failed to mutate resource", component.name)
+			return ctrl.Result{}, err
+		}
+
+		if resource.shouldExist {
+			result, err := controllerutil.CreateOrUpdate(ctx, r.Client, resource.object, resource.mutateFn)
+			if err != nil {
+				log.Error(err, "Failed to create or update "+component.name)
+				return ctrl.Result{}, err
+			}
+			switch result {
+			case controllerutil.OperationResultCreated:
+				log.Info("Created " + component.name)
+			case controllerutil.OperationResultUpdated:
+				log.Info("Updated " + component.name)
+			}
+
+			// apply any updates to status.clusterReference
+			if err := r.Status().Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
+
+			continue
+		}
+
+		// If we get this far, resource should not exist
+		// Ensure the resource does not exist, and call Delete if necessary
+		key := client.ObjectKeyFromObject(resource.object)
+		if err := r.Client.Get(ctx, key, resource.object); err != nil {
+			if apierrors.IsNotFound(err) {
+				// "not found" is the desired state. Nothing else to do.
+				continue
+			}
+			log.Error(err, "Get request for resource failed", component.name)
+			return ctrl.Result{}, err
+		}
+		err = r.Client.Delete(ctx, resource.object)
+		if err != nil {
+			log.Error(err, "Delete request for resource failed", component.name)
+			return ctrl.Result{}, err
+		}
+		log.Info("Deleted " + component.name)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ ctrl.Request, instance *cloudkitv1alpha1.ClusterOrder) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+	log.Info("Delete " + instance.GetName())
+
+	if controllerutil.ContainsFinalizer(instance, cloudkitFinalizer) {
+		labelSelector := client.MatchingLabels{cloudkitClusterOrderNameLabel: instance.GetName()}
+
+		var namespaceList corev1.NamespaceList
+		if err := r.List(ctx, &namespaceList, labelSelector); err != nil {
+			log.Error(err, "Failed to list Namespaces")
+			return ctrl.Result{}, err
+		}
+
+		if len(namespaceList.Items) == 0 {
+			controllerutil.RemoveFinalizer(instance, cloudkitFinalizer)
+			if err := r.Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
+		for _, ns := range namespaceList.Items {
+			if err := r.Client.Delete(ctx, &ns); err != nil {
+				log.Error(err, "Failed to delete namespace "+ns.GetName())
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
 }

--- a/internal/controller/clusterorder_controller_test.go
+++ b/internal/controller/clusterorder_controller_test.go
@@ -51,7 +51,9 @@ var _ = Describe("ClusterOrder Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
+					Spec: cloudkitv1alpha1.ClusterOrderSpec{
+						TemplateID: "test",
+					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}

--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"fmt"
+
+	cloudkitv1alpha1 "github.com/innabox/cloudkit-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+const (
+	defaultServiceAccountName string = "cloudkit"
+	defaultHostedClusterName  string = "cluster"
+	defaultRoleBindingName    string = "cloudkit"
+	cloudkitAppName           string = "cloudkit-operator"
+
+	cloudkitNamePrefix string = "cloudkit.openshift.io"
+)
+
+var (
+	cloudkitClusterOrderNameLabel      string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
+	cloudkitClusterOrderNamespaceLabel string = fmt.Sprintf("%s/clusterordernamespace", cloudkitNamePrefix)
+	cloudkitFinalizer                  string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
+)
+
+func generateNamespaceName(instance *cloudkitv1alpha1.ClusterOrder) string {
+	return fmt.Sprintf("cluster-%s-%s", instance.GetName(), rand.String(6))
+}

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -1,0 +1,140 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	cloudkitv1alpha1 "github.com/innabox/cloudkit-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *ClusterOrderReconciler) newNamespace(ctx context.Context, instance *cloudkitv1alpha1.ClusterOrder) (*appResource, error) {
+	namespaceName := instance.GetClusterReferenceNamespace()
+	if namespaceName == "" {
+		namespaceName = generateNamespaceName(instance)
+		if namespaceName == "" {
+			return nil, fmt.Errorf("failed to generate namespace name")
+		}
+	}
+
+	namespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespaceName,
+			Labels: commonLabelsFromOrder(instance),
+		},
+	}
+
+	instance.SetClusterReferenceNamespace(namespaceName)
+
+	mutateFn := func() error {
+		ensureCommonLabels(instance, namespace)
+		return nil
+	}
+
+	return &appResource{
+		namespace,
+		mutateFn,
+		true,
+	}, nil
+}
+
+func (r *ClusterOrderReconciler) newServiceAccount(ctx context.Context, instance *cloudkitv1alpha1.ClusterOrder) (*appResource, error) {
+	namespaceName := instance.GetClusterReferenceNamespace()
+	if namespaceName == "" {
+		return nil, fmt.Errorf("unable to retrieve required information from spec.clusterReference")
+	}
+
+	serviceAccountName := defaultServiceAccountName
+	instance.SetClusterReferenceServiceAccountName(serviceAccountName)
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: namespaceName,
+			Labels:    commonLabelsFromOrder(instance),
+		},
+	}
+
+	mutateFn := func() error {
+		ensureCommonLabels(instance, sa)
+		return nil
+	}
+
+	return &appResource{
+		sa,
+		mutateFn,
+		true,
+	}, nil
+}
+
+func (r *ClusterOrderReconciler) newAdminRoleBinding(ctx context.Context, instance *cloudkitv1alpha1.ClusterOrder) (*appResource, error) {
+	namespaceName := instance.GetClusterReferenceNamespace()
+	serviceAccountName := instance.GetClusterReferenceServiceAccountName()
+	if namespaceName == "" || serviceAccountName == "" {
+		return nil, fmt.Errorf("unable to retrieve required information from spec.clusterReference")
+	}
+
+	roleBindingName := defaultRoleBindingName
+
+	subjects := []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: namespaceName,
+		},
+	}
+
+	roleref := rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "ClusterRole",
+		Name:     "admin",
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: namespaceName,
+			Labels:    commonLabelsFromOrder(instance),
+		},
+	}
+
+	instance.SetClusterReferenceRoleBindingName(roleBindingName)
+
+	mutateFn := func() error {
+		ensureCommonLabels(instance, roleBinding)
+		roleBinding.Subjects = subjects
+		roleBinding.RoleRef = roleref
+		return nil
+	}
+
+	return &appResource{
+		roleBinding,
+		mutateFn,
+		true,
+	}, nil
+}
+
+func ensureCommonLabels(instance *cloudkitv1alpha1.ClusterOrder, obj client.Object) {
+	requiredLabels := commonLabelsFromOrder(instance)
+	objLabels := obj.GetLabels()
+	if objLabels == nil {
+		objLabels = make(map[string]string)
+	}
+	for k, v := range requiredLabels {
+		objLabels[k] = v
+	}
+	obj.SetLabels(objLabels)
+}
+
+func commonLabelsFromOrder(instance *cloudkitv1alpha1.ClusterOrder) map[string]string {
+	key := client.ObjectKeyFromObject(instance)
+	return map[string]string{
+		"app.kubernetes.io/name":           cloudkitAppName,
+		cloudkitClusterOrderNameLabel:      key.Name,
+		cloudkitClusterOrderNamespaceLabel: key.Namespace,
+	}
+}


### PR DESCRIPTION
When a new ClusterOrder is created, update .status.clusterReference and
create dependent resources (namespace, service account, rolebinding). When
a ClusterOrder is deleted, delete the namespace (and transitively delete
all the resources contained in the namespace).

Because we're creating resources in a namespace different from the one in
which the ClusterOrder is created, we're relying on labels to manage watch
events and trigger reconciliation.

NB: This PR is on top of #8 and #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new field for role binding in ClusterOrder resources and updated the CRD schema to include it, ensuring enhanced configuration and validation.
  - Improved overall resource management, resulting in more robust orchestration of namespaces, service accounts, and role bindings.
  - Introduced a naming convention for CloudKit resources and a utility for generating unique namespace names.
  - Updated the operator image version to reflect the latest development branch.

- **Chores**
  - Refined configuration for code quality tools and dependency management.
  - Enhanced access permissions to better support resource operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->