### PR TITLE
Change format of `templateID` to UUID

### DIFF
--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -29,7 +29,7 @@ type ClusterOrderSpec struct {
 	// TemplateID is the unique identigier of the cluster template to use when creating this cluster
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=`^[a-z][-a-z0-9]*[a-z0-9]$`
+	// +kubebuilder:validation:Format=uuid
 	TemplateID string `json:"templateID,omitempty"`
 }
 

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -42,7 +42,7 @@ spec:
               templateID:
                 description: TemplateID is the unique identigier of the cluster template
                   to use when creating this cluster
-                pattern: ^[a-z][-a-z0-9]*[a-z0-9]$
+                format: uuid
                 type: string
             required:
             - templateID


### PR DESCRIPTION
In the fulfillment service the template identifier is an UUID, but the operator currently requires it to start with a letter. This patch fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The validation for template identifiers has been updated. Users now need to provide a valid UUID instead of a custom string format, ensuring consistent input and reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->