### PR TITLE
Add support for template parameters to CRD

### DIFF
--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -98,6 +98,7 @@ type ClusterOrderStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=cord
 
 // ClusterOrder is the Schema for the clusterorders API
 type ClusterOrder struct {

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -29,7 +29,7 @@ type ClusterOrderSpec struct {
 	// TemplateID is the unique identigier of the cluster template to use when creating this cluster
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Format=uuid
+	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
 	TemplateID string `json:"templateID,omitempty"`
 	// +kubebuilder:validation:Optional
 	TemplateParameters string `json:"templateParameters,omitempty"`

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -31,6 +31,8 @@ type ClusterOrderSpec struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=uuid
 	TemplateID string `json:"templateID,omitempty"`
+	// +kubebuilder:validation:Optional
+	TemplateParameters string `json:"templateParameters,omitempty"`
 }
 
 // ClusterOrderPhaseType is a valid value for .status.phase

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -44,7 +44,7 @@ spec:
               templateID:
                 description: TemplateID is the unique identigier of the cluster template
                   to use when creating this cluster
-                format: uuid
+                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                 type: string
               templateParameters:
                 type: string

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ClusterOrder
     listKind: ClusterOrderList
     plural: clusterorders
+    shortNames:
+    - cord
     singular: clusterorder
   scope: Namespaced
   versions:

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -46,6 +46,8 @@ spec:
                   to use when creating this cluster
                 format: uuid
                 type: string
+              templateParameters:
+                type: string
             required:
             - templateID
             type: object


### PR DESCRIPTION
Update the ClusterOrder type to include a templateParameters field. This is
a string blob, and is expected to contain the JSON serialized parameter
map:

    spec:
      templateID: default
      templateParameters: |
        {
          "basedomain": "example.com"
        }

This also updates the validation for `templateID` per our call this morning.

NB: This PR is on top of #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced operator functionality for managing cluster orders with advanced webhook support and refined resource lifecycle processing.
  - Updated resource definitions with streamlined validation rules and a concise short name for easier management.
  - Expanded permissions to better handle namespaces, service accounts, and role bindings.
  - Introduced new methods for managing cluster references and generating Kubernetes resources associated with cluster orders.

- **Documentation**
  - Revised overview with clearer details on operator functionality and environment variable configuration.

- **Chores**
  - Upgraded runtime, dependencies, and controller image configuration for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->