### PR TITLE
Fix label predicate in SetupWithManager

### DIFF
--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -99,8 +99,11 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterOrderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	labelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			cloudkitClusterOrderNameLabel: "",
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      cloudkitClusterOrderNameLabel,
+				Operator: metav1.LabelSelectorOpExists,
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
In order to test for the existence of a label, we need to use MatchExpressions rather than MatchLabels.