### PR TITLE
Remove unused code and update log messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= podman
 
 # KIND defines the path to your kind binary.
 KIND = kind
@@ -150,7 +150,7 @@ image-build: ## Build container image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} -f ${CONTAINERFILE} .
 
 .PHONY: docker-push
-docker-push: ## Push container image with the manager.
+image-push: ## Push container image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
 .PHONY: kind-load

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -39,7 +39,6 @@ func (r *ClusterOrderReconciler) newNamespace(ctx context.Context, instance *v1a
 	return &appResource{
 		namespace,
 		mutateFn,
-		true,
 	}, nil
 }
 
@@ -68,7 +67,6 @@ func (r *ClusterOrderReconciler) newServiceAccount(ctx context.Context, instance
 	return &appResource{
 		sa,
 		mutateFn,
-		true,
 	}, nil
 }
 
@@ -115,7 +113,6 @@ func (r *ClusterOrderReconciler) newAdminRoleBinding(ctx context.Context, instan
 	return &appResource{
 		roleBinding,
 		mutateFn,
-		true,
 	}, nil
 }
 


### PR DESCRIPTION
This is a maintenance change that doesn't have any operational impact on the code. It is primarily code cleanup, log message improvements, and de-emphasizing docker in the Makefile.