### PR TITLE
A bundle of small changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,12 +146,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.ClusterOrderReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		CreateClusterWebhook: os.Getenv("CLOUDKIT_CLUSTER_CREATE_WEBHOOK"),
-		DeleteClusterWebhook: os.Getenv("CLOUDKIT_CLUSTER_DELETE_WEBHOOK"),
-	}).SetupWithManager(mgr); err != nil {
+	if err = (controller.NewClusterOrderReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		os.Getenv("CLOUDKIT_CLUSTER_CREATE_WEBHOOK"),
+		os.Getenv("CLOUDKIT_CLUSTER_DELETE_WEBHOOK"),
+		os.Getenv("CLOUDKIT_CLUSTER_ORDER_NAMESPACE"),
+	)).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterOrder")
 		os.Exit(1)
 	}

--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	defaultServiceAccountName string = "cloudkit"
-	defaultHostedClusterName  string = "cluster"
-	defaultRoleBindingName    string = "cloudkit"
-	cloudkitAppName           string = "cloudkit-operator"
+	defaultServiceAccountName    string = "cloudkit"
+	defaultHostedClusterName     string = "cluster"
+	defaultRoleBindingName       string = "cloudkit"
+	defaultClusterOrderNamespace string = "cloudkit-orders"
+	cloudkitAppName              string = "cloudkit-operator"
 
 	cloudkitNamePrefix string = "cloudkit.openshift.io"
 )

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -29,10 +29,9 @@ func (r *ClusterOrderReconciler) newNamespace(ctx context.Context, instance *v1a
 		},
 	}
 
-	instance.SetClusterReferenceNamespace(namespaceName)
-
 	mutateFn := func() error {
 		ensureCommonLabels(instance, namespace)
+		instance.SetClusterReferenceNamespace(namespaceName)
 		return nil
 	}
 
@@ -49,7 +48,6 @@ func (r *ClusterOrderReconciler) newServiceAccount(ctx context.Context, instance
 	}
 
 	serviceAccountName := defaultServiceAccountName
-	instance.SetClusterReferenceServiceAccountName(serviceAccountName)
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,6 +59,7 @@ func (r *ClusterOrderReconciler) newServiceAccount(ctx context.Context, instance
 
 	mutateFn := func() error {
 		ensureCommonLabels(instance, sa)
+		instance.SetClusterReferenceServiceAccountName(serviceAccountName)
 		return nil
 	}
 
@@ -101,9 +100,8 @@ func (r *ClusterOrderReconciler) newAdminRoleBinding(ctx context.Context, instan
 		},
 	}
 
-	instance.SetClusterReferenceRoleBindingName(roleBindingName)
-
 	mutateFn := func() error {
+		instance.SetClusterReferenceRoleBindingName(roleBindingName)
 		ensureCommonLabels(instance, roleBinding)
 		roleBinding.Subjects = subjects
 		roleBinding.RoleRef = roleref


### PR DESCRIPTION
This PR includes a few minor changes:

- Only respond to ClusterOrders in a specific namespace

  We want to only watch ClusterOrder in a specific namespace. This will
  ultimately simplify some aspects of the design and will effectively enforce
  unique names on ClusterOrders (which is not the case when they can be
  create in arbitrary namespaces).

  The solution here is sub-optimal and will be replaced in a subsequence
  change.

- Find namespace using a label selector

  Since we generate the name with a random suffix it cannot be inferred from
  the ClusterOrder. We need to find it using a label selector in order to
  update status.clsuterReference appropriately.

- Update clusterference inside mutate function

- Add methods to ClusterOrder for setting conditions

  Add helper functions to the ClusterOrder type for setting, removing, and
  testing status conditions.

This PR applies on top of -- and includes -- #17.
