### PR TITLE
Update deployment manifests

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: cloudkit-operator
-  newTag: devel
+  newName: ghcr.io/innabox/cloudkit-operator
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,17 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
+        envFrom:
+          - secretRef:
+              name: cloudkit-webhooks
+              optional: true
+        env:
+          - name: CLOUDKIT_CLUSTER_ORDER_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/rbac/admin_role_binding.yaml
+++ b/config/rbac/admin_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: cloudkit-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-admin-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- admin_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # The following RBAC configurations are used to protect


### PR DESCRIPTION
- Update go version used to build container image

- Bind manager service account to admin clusterrole

  In order to grant the `admin` role to the per-cluster service accounts we
  create, the manager service account must have that role cluster-wide.
  Otherwise, creating the new rolebinding will fail with:

      rolebindings.rbac.authorization.k8s.io "cloudkit" is forbidden: user
      "system:serviceaccount:cloudkit-operator-system:cloudkit-operator-controller-manager"
      (groups=["system:serviceaccounts"
      "system:serviceaccounts:cloudkit-operator-system"
      "system:authenticated"]) is attempting to grant RBAC permissions not
      currently held: ...

- Add environment variables to manifests

  Update the deployment manifest to use the namespace in which the operator
  is deployed as CLOUDKIT_CLUSTER_ORDER_NAMESPACE, and optionall load webhook
  environment variables from a secret.

  We also set `imagePullPolicy: Always` to make life easier during
  development.

This pull requests applies on top of -- and includes -- #18.