### PR TITLE
Drop the cloudkit.openshift.io/clusterordernamespace label

### DIFF
--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -180,18 +180,13 @@ func (r *ClusterOrderReconciler) mapObjectToCluster(ctx context.Context, obj cli
 		return nil
 	}
 
-	clusterOrderNamespace, exists := obj.GetLabels()[cloudkitClusterOrderNamespaceLabel]
-	if !exists {
-		return nil
-	}
-
 	log.Info("Selecting " + obj.GetName())
 
 	return []reconcile.Request{
 		{
 			NamespacedName: client.ObjectKey{
 				Name:      clusterOrderName,
-				Namespace: clusterOrderNamespace,
+				Namespace: r.ClusterOrderNamespace,
 			},
 		},
 	}
@@ -340,7 +335,6 @@ func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ ctrl.Reques
 
 func labelSelectorFromInstance(instance *v1alpha1.ClusterOrder) client.MatchingLabels {
 	return client.MatchingLabels{
-		cloudkitClusterOrderNamespaceLabel: instance.GetNamespace(),
-		cloudkitClusterOrderNameLabel:      instance.GetName(),
+		cloudkitClusterOrderNameLabel: instance.GetName(),
 	}
 }

--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -18,9 +18,8 @@ const (
 )
 
 var (
-	cloudkitClusterOrderNameLabel      string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
-	cloudkitClusterOrderNamespaceLabel string = fmt.Sprintf("%s/clusterordernamespace", cloudkitNamePrefix)
-	cloudkitFinalizer                  string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
+	cloudkitClusterOrderNameLabel string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
+	cloudkitFinalizer             string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
 )
 
 func generateNamespaceName(instance *v1alpha1.ClusterOrder) string {

--- a/internal/controller/clusterorder_resources.go
+++ b/internal/controller/clusterorder_resources.go
@@ -144,8 +144,7 @@ func ensureCommonLabels(instance *v1alpha1.ClusterOrder, obj client.Object) {
 func commonLabelsFromOrder(instance *v1alpha1.ClusterOrder) map[string]string {
 	key := client.ObjectKeyFromObject(instance)
 	return map[string]string{
-		"app.kubernetes.io/name":           cloudkitAppName,
-		cloudkitClusterOrderNameLabel:      key.Name,
-		cloudkitClusterOrderNamespaceLabel: key.Namespace,
+		"app.kubernetes.io/name":      cloudkitAppName,
+		cloudkitClusterOrderNameLabel: key.Name,
 	}
 }


### PR DESCRIPTION
Because we now only watch for orders in a single namespace, this label is no longer necessary.