### PR TITLE
Example of how to send updates to the fulfillment service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -193,6 +193,17 @@ func main() {
 			os.Exit(1)
 		}
 		defer grpcConn.Close() //nolint:errcheck
+		if err = (controller.NewFeedbackReconciler(
+			mgr.GetClient(),
+			grpcConn,
+		)).SetupWithManager(mgr); err != nil {
+			setupLog.Error(
+				err,
+				"unable to create feedback controller",
+				"controller", "Feedback",
+			)
+			os.Exit(1)
+		}
 	} else {
 		setupLog.Info("gRPC connection to fulfillment service is disabled")
 	}
@@ -203,11 +214,11 @@ func main() {
 		os.Getenv("CLOUDKIT_CLUSTER_CREATE_WEBHOOK"),
 		os.Getenv("CLOUDKIT_CLUSTER_DELETE_WEBHOOK"),
 		os.Getenv("CLOUDKIT_CLUSTER_ORDER_NAMESPACE"),
-		grpcConn,
 	)).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterOrder")
 		os.Exit(1)
 	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -69,7 +68,6 @@ type ClusterOrderReconciler struct {
 	CreateClusterWebhook  string
 	DeleteClusterWebhook  string
 	ClusterOrderNamespace string
-	GrpcConn              *grpc.ClientConn
 }
 
 func NewClusterOrderReconciler(
@@ -78,7 +76,6 @@ func NewClusterOrderReconciler(
 	createClusterWebhook string,
 	deleteClusterWebhook string,
 	clusterOrderNamespace string,
-	grpcConn *grpc.ClientConn,
 ) *ClusterOrderReconciler {
 	if clusterOrderNamespace == "" {
 		clusterOrderNamespace = defaultClusterOrderNamespace
@@ -89,7 +86,6 @@ func NewClusterOrderReconciler(
 		CreateClusterWebhook:  createClusterWebhook,
 		DeleteClusterWebhook:  deleteClusterWebhook,
 		ClusterOrderNamespace: clusterOrderNamespace,
-		GrpcConn:              grpcConn,
 	}
 }
 

--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	cloudkitClusterOrderNameLabel string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
+	cloudkitClusterOrderIdLabel   string = fmt.Sprintf("%s/clusterorder-uuid", cloudkitNamePrefix)
 	cloudkitFinalizer             string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
 )
 

--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller implements the controller logic
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/innabox/cloudkit-operator/api/v1alpha1"
+	fulfillmentv1 "github.com/innabox/cloudkit-operator/internal/api/fulfillment/v1"
+	sharedv1 "github.com/innabox/cloudkit-operator/internal/api/shared/v1"
+)
+
+// FeedbackReconciler sends updates to the fulfillment service API.
+type FeedbackReconciler struct {
+	client.Client
+	ClusterOrdersClient fulfillmentv1.ClusterOrdersClient
+	ClustersClient      fulfillmentv1.ClustersClient
+}
+
+func NewFeedbackReconciler(client client.Client, grpcConn *grpc.ClientConn) *FeedbackReconciler {
+	return &FeedbackReconciler{
+		Client:              client,
+		ClusterOrdersClient: fulfillmentv1.NewClusterOrdersClient(grpcConn),
+		ClustersClient:      fulfillmentv1.NewClustersClient(grpcConn),
+	}
+}
+
+func (r *FeedbackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {
+	instance := &v1alpha1.ClusterOrder{}
+	err = r.Client.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		err = client.IgnoreNotFound(err)
+		return
+	}
+	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		result, err = r.handleUpdate(ctx, instance)
+	} else {
+		result, err = r.handleDelete(ctx, instance)
+	}
+	return
+}
+
+func (r *FeedbackReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.ClusterOrder{}).
+		Complete(r)
+}
+
+func (r *FeedbackReconciler) handleUpdate(ctx context.Context, instance *v1alpha1.ClusterOrder) (result ctrl.Result,
+	err error) {
+	logger := ctrllog.FromContext(ctx)
+
+	// Get the identifier of the order from the labels:
+	clusterOrderId, ok := instance.Labels[cloudkitClusterOrderIdLabel]
+	if !ok {
+		logger.Info(
+			"There is no label containing the cluster order identifier, will ignore it",
+			"label", cloudkitClusterOrderIdLabel,
+		)
+		return
+	}
+
+	// Try to fetch the current representation of the cluster order:
+	getRequest, err := r.ClusterOrdersClient.Get(ctx, &fulfillmentv1.ClusterOrdersGetRequest{
+		Id: clusterOrderId,
+	})
+	if grpcstatus.Code(err) == grpccodes.NotFound {
+		logger.Info(
+			"Cluster order doesn't exist, will ignore it",
+			"id", clusterOrderId,
+			"error", err.Error(),
+		)
+		err = nil
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	// Update the conditions to indicate that we the order has been accepted:
+	clusterOrder := getRequest.Object
+	if clusterOrder.Status == nil {
+		clusterOrder.Status = &fulfillmentv1.ClusterOrderStatus{}
+	}
+	acceptedCondition := r.findOrCreateCondition(
+		clusterOrder,
+		fulfillmentv1.ClusterOrderConditionType_CLUSTER_ORDER_CONDITION_TYPE_ACCEPTED,
+	)
+	acceptedCondition.Status = sharedv1.ConditionStatus_CONDITION_STATUS_TRUE
+	acceptedCondition.Reason = proto.String("KubernetesObjectCreated")
+	acceptedCondition.Message = proto.String(fmt.Sprintf(
+		"The kubernetes object '%s' has been created in namespace '%s'",
+		instance.Name, instance.Namespace,
+	))
+
+	// Update the cluster order:
+	_, err = r.ClusterOrdersClient.Update(ctx, &fulfillmentv1.ClusterOrdersUpdateRequest{
+		Object: clusterOrder,
+	})
+	if err != nil {
+		return
+	}
+	logger.Info(
+		"Cluster order updated",
+		"id", clusterOrderId,
+	)
+
+	return
+}
+
+func (r *FeedbackReconciler) handleDelete(ctx context.Context, instance *v1alpha1.ClusterOrder) (result ctrl.Result,
+	err error) {
+	// TODO.
+	return
+}
+
+func (r *FeedbackReconciler) findOrCreateCondition(clusterOrder *fulfillmentv1.ClusterOrder,
+	conditionType fulfillmentv1.ClusterOrderConditionType) *fulfillmentv1.ClusterOrderCondition {
+	var condition *fulfillmentv1.ClusterOrderCondition
+	for _, current := range clusterOrder.Status.Conditions {
+		if current.Type == conditionType {
+			condition = current
+			break
+		}
+	}
+	if condition == nil {
+		condition = &fulfillmentv1.ClusterOrderCondition{
+			Type:               conditionType,
+			Status:             sharedv1.ConditionStatus_CONDITION_STATUS_FALSE,
+			LastTransitionTime: timestamppb.Now(),
+		}
+		clusterOrder.Status.Conditions = append(clusterOrder.Status.Conditions, condition)
+	}
+	return condition
+}


### PR DESCRIPTION
This patch adds a new _Feedback_ controller that watches the cluster objecs and sends feedback to the fulfillment service. Currently it just udates the `ACCEPTED` condition adding a message that contains the name and namespace of the Kubernetes object. That results in orders like this (converted to YAML):

```yaml
- id: 7153b079-9ae1-4852-8b20-0a8b9c3ba2a6
  metadata:
    creation_timestamp: "2025-04-08T16:35:56.469795Z"
  spec:
    template_id: ocp_4_17_small
  status:
    conditions:
      - status: CONDITION_STATUS_FALSE
        type: CLUSTER_ORDER_CONDITION_TYPE_CANCELED
      - status: CONDITION_STATUS_FALSE
        type: CLUSTER_ORDER_CONDITION_TYPE_FULFILLED
      - status: CONDITION_STATUS_FALSE
        type: CLUSTER_ORDER_CONDITION_TYPE_FAILED
      - message: The kubernetes object 'order-zdzmd' has been created in namespace 'cloudkit-operator-system'
        reason: KubernetesObjectCreated
        status: CONDITION_STATUS_TRUE
        type: CLUSTER_ORDER_CONDITION_TYPE_ACCEPTED
      - status: CONDITION_STATUS_FALSE
        type: CLUSTER_ORDER_CONDITION_TYPE_REJECTED
    state: CLUSTER_ORDER_STATE_PROGRESSING
```