### PR TITLE
Add missing generated files

### DIFF
--- a/internal/api/fulfillment/v1/cluster_order_type.pb.go
+++ b/internal/api/fulfillment/v1/cluster_order_type.pb.go
@@ -507,7 +507,7 @@ type ClusterOrderStatus struct {
 	//
 	// This will be automatically populated by the system when the requested cluster is completely provisoned. Further
 	// details about the cluster, like the API URL, will be available in the corresponding `Cluster` object.
-	ClusterId     string `protobuf:"bytes,3,opt,name=cluster_id,json=clusterID,proto3" json:"cluster_id,omitempty"`
+	ClusterId     string `protobuf:"bytes,3,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/internal/api/fulfillment/v1/cluster_order_type_protoopaque.pb.go
+++ b/internal/api/fulfillment/v1/cluster_order_type_protoopaque.pb.go
@@ -411,7 +411,7 @@ type ClusterOrderStatus struct {
 	state                 protoimpl.MessageState    `protogen:"opaque.v1"`
 	xxx_hidden_State      ClusterOrderState         `protobuf:"varint,1,opt,name=state,proto3,enum=fulfillment.v1.ClusterOrderState"`
 	xxx_hidden_Conditions *[]*ClusterOrderCondition `protobuf:"bytes,2,rep,name=conditions,proto3"`
-	xxx_hidden_ClusterId  string                    `protobuf:"bytes,3,opt,name=cluster_id,json=clusterID,proto3"`
+	xxx_hidden_ClusterId  string                    `protobuf:"bytes,3,opt,name=cluster_id,json=clusterId,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }

--- a/internal/api/fulfillment/v1/cluster_type.pb.go
+++ b/internal/api/fulfillment/v1/cluster_type.pb.go
@@ -378,11 +378,11 @@ type ClusterStatus struct {
 	// URL of te API server of the cluster.
 	//
 	// This will be empty if the cluster isn't ready.
-	ApiUrl string `protobuf:"bytes,3,opt,name=api_url,json=apiURL,proto3" json:"api_url,omitempty"`
+	ApiUrl string `protobuf:"bytes,3,opt,name=api_url,json=apiUrl,proto3" json:"api_url,omitempty"`
 	// URL of the console of the cluster.
 	//
 	// This will be empty if the cluster isn't ready or the console isn't enabled.
-	ConsoleUrl    string `protobuf:"bytes,4,opt,name=console_url,json=consoleURL,proto3" json:"console_url,omitempty"`
+	ConsoleUrl    string `protobuf:"bytes,4,opt,name=console_url,json=consoleUrl,proto3" json:"console_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/internal/api/fulfillment/v1/cluster_type_protoopaque.pb.go
+++ b/internal/api/fulfillment/v1/cluster_type_protoopaque.pb.go
@@ -337,8 +337,8 @@ type ClusterStatus struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_State      ClusterState           `protobuf:"varint,1,opt,name=state,proto3,enum=fulfillment.v1.ClusterState"`
 	xxx_hidden_Conditions *[]*ClusterCondition   `protobuf:"bytes,2,rep,name=conditions,proto3"`
-	xxx_hidden_ApiUrl     string                 `protobuf:"bytes,3,opt,name=api_url,json=apiURL,proto3"`
-	xxx_hidden_ConsoleUrl string                 `protobuf:"bytes,4,opt,name=console_url,json=consoleURL,proto3"`
+	xxx_hidden_ApiUrl     string                 `protobuf:"bytes,3,opt,name=api_url,json=apiUrl,proto3"`
+	xxx_hidden_ConsoleUrl string                 `protobuf:"bytes,4,opt,name=console_url,json=consoleUrl,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }

--- a/internal/api/private/v1/cluster_type.pb.go
+++ b/internal/api/private/v1/cluster_type.pb.go
@@ -50,7 +50,7 @@ type Cluster struct {
 	// This is needed because the way to find the Kubernetes `ClusterOrder` object corresponding to this cluster is to
 	// use the `.../clusterorder-uuid` label that was set when it was created, and that contains the identifier of the
 	// cluster order because at that point there is no cluster yet.
-	OrderId       string `protobuf:"bytes,4,opt,name=order_id,json=orderID,proto3" json:"order_id,omitempty"`
+	OrderId       string `protobuf:"bytes,4,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/internal/api/private/v1/cluster_type_protoopaque.pb.go
+++ b/internal/api/private/v1/cluster_type_protoopaque.pb.go
@@ -42,7 +42,7 @@ type Cluster struct {
 	xxx_hidden_Id       string                 `protobuf:"bytes,1,opt,name=id,proto3"`
 	xxx_hidden_Metadata *v1.Metadata           `protobuf:"bytes,2,opt,name=metadata,proto3"`
 	xxx_hidden_HubId    string                 `protobuf:"bytes,3,opt,name=hub_id,json=hubId,proto3"`
-	xxx_hidden_OrderId  string                 `protobuf:"bytes,4,opt,name=order_id,json=orderID,proto3"`
+	xxx_hidden_OrderId  string                 `protobuf:"bytes,4,opt,name=order_id,json=orderId,proto3"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }


### PR DESCRIPTION
A previous patch didn't add some of the generated protobuf files that are needed to build. This patch adds them.