### PR TITLE
Enable the feedback controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,14 +98,14 @@ func main() {
 	)
 	flag.StringVar(
 		&grpcTokenFile,
-		"grpc-token-file",
-		"",
-		"Path of the file containing the token for gRPC authentication.",
+		"fulfillment-server-token-file",
+		os.Getenv("CLOUDKIT_FULFILLMENT_TOKEN_FILE"),
+		"Path of the file containing the token for gRPC authentication to the fulfillment service.",
 	)
 	flag.StringVar(
 		&fulfillmentServerAddress,
 		"fulfillment-server-address",
-		"",
+		os.Getenv("CLOUDKIT_FULFILLMENT_SERVER_ADDRESS"),
 		"Address of the fulfillment server.",
 	)
 	opts := zap.Options{

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,6 +63,9 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --grpc-insecure
+          - --grpc-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - --fulfillment-server-address=fulfillment-api.innabox.svc:8000
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,14 +64,12 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --grpc-insecure
-          - --grpc-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
-          - --fulfillment-server-address=fulfillment-api.innabox.svc:8000
         image: controller:latest
         imagePullPolicy: Always
         name: manager
         envFrom:
           - secretRef:
-              name: cloudkit-webhooks
+              name: cloudkit-config
               optional: true
         env:
           - name: CLOUDKIT_CLUSTER_ORDER_NAMESPACE


### PR DESCRIPTION
This patch adds the `--fulfillment-server-address` flag to the command line of the controller manager, so that the fulfillment controller will be enabled.