### PR TITLE
Copy all source files into container build environment

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -2,6 +2,7 @@ name: Build container image
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
     - main

--- a/Containerfile
+++ b/Containerfile
@@ -12,9 +12,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY . ./
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
The Containerfile was previously too granular and was not copying the
complete source tree into the build environment, resulting in failed
builds.
