### PR TITLE
Fix error regarding duplicate controller names

### DIFF
--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -70,6 +70,7 @@ func NewFeedbackReconciler(logger logr.Logger, hubClient clnt.Client, grpcConn *
 // SetupWithManager adds the reconciler to the controller manager.
 func (r *FeedbackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("clusterorder-feedback").
 		For(&ckv1alpha1.ClusterOrder{}).
 		Complete(r)
 }


### PR DESCRIPTION
The operator was failing with the error:

> ERROR   setup   unable to create controller     {"controller":
> "ClusterOrder", "error": "controller with name clusterorder already exists.
> Controller names must be unique to avoid multiple controllers reporting to
> the same metric"}

This is caused because the default controller name is built by lowercasing
the resource name passed in the `For` method:

    func (r *FeedbackReconciler) SetupWithManager(mgr ctrl.Manager) error {
            return ctrl.NewControllerManagedBy(mgr).
                    For(&ckv1alpha1.ClusterOrder{}).
                    Complete(r)
    }

Since both the primary controller and the feedback controller are watching
the ClusterOrder resource, they ended up having the same name. We can fix
this by explicitly naming the feedback controller.
