### PR TITLE
Accept dots in template ids

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,5 +25,3 @@ jobs:
           go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.0

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -29,7 +29,7 @@ type ClusterOrderSpec struct {
 	// TemplateID is the unique identigier of the cluster template to use when creating this cluster
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
+	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9._]*$
 	TemplateID string `json:"templateID,omitempty"`
 	// TemplateParameters is a JSON-encoded map of the parameter values for the
 	// selected cluster template.

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -64,7 +64,7 @@ spec:
               templateID:
                 description: TemplateID is the unique identigier of the cluster template
                   to use when creating this cluster
-                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                pattern: ^[a-zA-Z_][a-zA-Z0-9._]*$
                 type: string
               templateParameters:
                 description: |-


### PR DESCRIPTION
As previously discussed, modify the controller to accept "templateID"
values that contains dots (.) so that we can use fully qualified template
names like `cloudkit.templates.ocp_4_17_small`.

Closes innabox/issues#114