### PR TITLE
Fake fulfilled status for cluster order

### DIFF
--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -136,6 +136,10 @@ type ClusterOrderList struct {
 	Items           []ClusterOrder `json:"items"`
 }
 
+func (co *ClusterOrder) SetPhase(phase ClusterOrderPhaseType) {
+	co.Status.Phase = phase
+}
+
 func init() {
 	SchemeBuilder.Register(&ClusterOrder{}, &ClusterOrderList{})
 }

--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -240,6 +240,7 @@ func (r *ClusterOrderReconciler) handleUpdate(ctx context.Context, _ ctrl.Reques
 
 		if controlPlaneIsAvailable(hc) {
 			instance.SetStatusCondition(v1alpha1.ConditionControlPlaneAvailable, metav1.ConditionTrue, "", v1alpha1.ReasonAsExpected)
+			instance.SetPhase(v1alpha1.ClusterOrderPhaseReady)
 		}
 	} else {
 		// only trigger webhook if the hostedcluster does not exist


### PR DESCRIPTION
We need cluster orders to reach the "fulfilled" state. We would normally
look at something like the `ClusterVersionAvailable` status on the
HostedCluster resource, but because of innabox/issues#112, that condition
is always False due to the failing cluster operators.

In this commit, we translate the `Available` status on the HostedCluster
resource to "fulfilled" status in the API.
