### PR TITLE
Save order identifier in private cluster

### DIFF
--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -377,7 +377,8 @@ func (t *feedbackReconcilerTask) syncPhaseReady(ctx context.Context) error {
 		publicClusterStatus.SetConsoleUrl(consoleURL)
 	}
 
-	// Save the hub identifier in the private cluster:
+	// Save the order and hub identifiers in the private cluster:
+	t.privateCluster.SetOrderId(t.publicOrder.GetId())
 	t.privateCluster.SetHubId(t.privateOrder.GetHubId())
 
 	return nil


### PR DESCRIPTION
We need to save the order indentifier in the private data of the cluster because it is needed to find the Kubernetes `ClusterOrder` that corresponds to that cluster.