### PR TITLE
Grant controller permission to read node pools

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -52,6 +52,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings


### PR DESCRIPTION
In order to send the descriptions of node pools to the fulfillment service the controller needs permission to read the `NodePool` objects.