### PR TITLE
Update phase

### DIFF
--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -55,9 +55,6 @@ type NodeRequest struct {
 type ClusterOrderPhaseType string
 
 const (
-	// ClusterOrderPhaseAccepted means the controller has received the ClusterOrder but has not started work
-	ClusterOrderPhaseAccepted ClusterOrderPhaseType = "Accepted"
-
 	// ClusterOrderPhaseProgressing means an update is in progress
 	ClusterOrderPhaseProgressing ClusterOrderPhaseType = "Progressing"
 
@@ -67,7 +64,7 @@ const (
 	// ClusterOrderPhaseReady means the cluster and all associated resources are ready
 	ClusterOrderPhaseReady ClusterOrderPhaseType = "Ready"
 
-	// ClusterOrderPhaseReady means the cluster and all associated resources are ready
+	// ClusterOrderPhaseDeleting means there has been a request to delete the ClusterOrder
 	ClusterOrderPhaseDeleting ClusterOrderPhaseType = "Deleting"
 )
 
@@ -102,7 +99,7 @@ type ClusterOrderStatus struct {
 	// Phase provides a single-value overview of the state of the ClusterOrder
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Enum=Unknown;Progressing;Failed;Ready;Deleting
+	// +kubebuilder:validation:Enum=Progressing;Failed;Ready;Deleting
 	Phase ClusterOrderPhaseType `json:"phase,omitempty"`
 
 	// Conditions holds an array of metav1.Condition that describe the state of the ClusterOrder
@@ -120,6 +117,8 @@ type ClusterOrderStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=cord
+// +kubebuilder:printcolumn:name="Template",type=string,JSONPath=`.spec.templateID`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 
 // ClusterOrder is the Schema for the clusterorders API
 type ClusterOrder struct {

--- a/api/v1alpha1/clusterorder_types.go
+++ b/api/v1alpha1/clusterorder_types.go
@@ -55,10 +55,7 @@ type NodeRequest struct {
 type ClusterOrderPhaseType string
 
 const (
-	// ClusterOrderPhaseUnknown is the zero value of .status.phase
-	ClusterOrderPhaseUnknown ClusterOrderPhaseType = "Unknown"
-
-	// ClusterOrderPhaseAccepted means the order has been accepted but work has not yet started
+	// ClusterOrderPhaseAccepted means the controller has received the ClusterOrder but has not started work
 	ClusterOrderPhaseAccepted ClusterOrderPhaseType = "Accepted"
 
 	// ClusterOrderPhaseProgressing means an update is in progress
@@ -70,8 +67,8 @@ const (
 	// ClusterOrderPhaseReady means the cluster and all associated resources are ready
 	ClusterOrderPhaseReady ClusterOrderPhaseType = "Ready"
 
-	// ClusterOrderPhaseCompleted means the cluster is completely ready for use
-	ClusterOrderPhaseCompleted ClusterOrderPhaseType = "Completed"
+	// ClusterOrderPhaseReady means the cluster and all associated resources are ready
+	ClusterOrderPhaseDeleting ClusterOrderPhaseType = "Deleting"
 )
 
 // ClusterOrderConditionType is a valid value for .status.conditions.type
@@ -105,7 +102,7 @@ type ClusterOrderStatus struct {
 	// Phase provides a single-value overview of the state of the ClusterOrder
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Enum=Unknown;Accepted;Progressing;Failed;Ready
+	// +kubebuilder:validation:Enum=Unknown;Progressing;Failed;Ready;Deleting
 	Phase ClusterOrderPhaseType `json:"phase,omitempty"`
 
 	// Conditions holds an array of metav1.Condition that describe the state of the ClusterOrder
@@ -140,10 +137,6 @@ type ClusterOrderList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterOrder `json:"items"`
-}
-
-func (co *ClusterOrder) SetPhase(phase ClusterOrderPhaseType) {
-	co.Status.Phase = phase
 }
 
 func init() {

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -16,7 +16,14 @@ spec:
     singular: clusterorder
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.templateID
+      name: Template
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ClusterOrder is the Schema for the clusterorders API
@@ -177,10 +184,10 @@ spec:
                   the ClusterOrder
                 enum:
                 - Unknown
-                - Accepted
                 - Progressing
                 - Failed
                 - Ready
+                - Deleting
                 type: string
             type: object
         type: object

--- a/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
+++ b/config/crd/bases/cloudkit.openshift.io_clusterorders.yaml
@@ -183,7 +183,6 @@ spec:
                 description: Phase provides a single-value overview of the state of
                   the ClusterOrder
                 enum:
-                - Unknown
                 - Progressing
                 - Failed
                 - Ready

--- a/internal/controller/clusterorder_controller.go
+++ b/internal/controller/clusterorder_controller.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -139,21 +138,11 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func NamespacePredicate(namespace string) predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetNamespace() == namespace
+	return predicate.NewPredicateFuncs(
+		func(obj client.Object) bool {
+			return obj.GetNamespace() == namespace
 		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetNamespace() == namespace
-			// You might also want to check e.ObjectOld if relevant for your logic
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetNamespace() == namespace
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return e.Object.GetNamespace() == namespace
-		},
-	}
+	)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -316,8 +316,6 @@ func (t *feedbackReconcilerTask) mapConditionStatus(status metav1.ConditionStatu
 
 func (t *feedbackReconcilerTask) syncPhase(ctx context.Context) error {
 	switch t.object.Status.Phase {
-	case ckv1alpha1.ClusterOrderPhaseAccepted:
-		return t.syncPhaseAccepted()
 	case ckv1alpha1.ClusterOrderPhaseProgressing:
 		return t.syncPhaseProgressing()
 	case ckv1alpha1.ClusterOrderPhaseFailed:
@@ -334,11 +332,6 @@ func (t *feedbackReconcilerTask) syncPhase(ctx context.Context) error {
 		)
 		return nil
 	}
-	return nil
-}
-
-func (t *feedbackReconcilerTask) syncPhaseAccepted() error {
-	t.publicOrder.GetStatus().SetState(ffv1.ClusterOrderState_CLUSTER_ORDER_STATE_PROGRESSING)
 	return nil
 }
 

--- a/internal/controller/feedback_controller.go
+++ b/internal/controller/feedback_controller.go
@@ -324,6 +324,9 @@ func (t *feedbackReconcilerTask) syncPhase(ctx context.Context) error {
 		return t.syncPhaseFailed()
 	case ckv1alpha1.ClusterOrderPhaseReady:
 		return t.syncPhaseReady(ctx)
+	case ckv1alpha1.ClusterOrderPhaseDeleting:
+		// TODO: There is no equivalent phase.
+		// return t.syncPhaseDeleting(ctx)
 	default:
 		t.r.logger.Info(
 			"Unknown phase, will ignore it",
@@ -331,6 +334,7 @@ func (t *feedbackReconcilerTask) syncPhase(ctx context.Context) error {
 		)
 		return nil
 	}
+	return nil
 }
 
 func (t *feedbackReconcilerTask) syncPhaseAccepted() error {


### PR DESCRIPTION
- Show template name and phase in kubectl get output
  
  This shows the template id and current phase in the output of `kubectl get
  clusterorder`. The output looks like this:
  
  ```
  NAME          TEMPLATE                            PHASE
  order-xm7bl   cloudkit.templates.ocp_4_17_small   Progressing
  ```

- Update clusterorder phase
  
  This updates .status.phase on ClusterOrder instances at strategic points.
  It currently handles three "phases":
  
  - Progressing
  - Ready
  - Deleting
  
  This is useful to figure out whether a cluster is ready or if it is trying
  to delete.
