### PR TITLE
Teach controller about cloudkit.openshift.io/management-state annotation

### DIFF
--- a/internal/controller/clusterorder_names.go
+++ b/internal/controller/clusterorder_names.go
@@ -18,9 +18,10 @@ const (
 )
 
 var (
-	cloudkitClusterOrderNameLabel string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
-	cloudkitClusterOrderIDLabel   string = fmt.Sprintf("%s/clusterorder-uuid", cloudkitNamePrefix)
-	cloudkitFinalizer             string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
+	cloudkitClusterOrderNameLabel     string = fmt.Sprintf("%s/clusterorder", cloudkitNamePrefix)
+	cloudkitClusterOrderIDLabel       string = fmt.Sprintf("%s/clusterorder-uuid", cloudkitNamePrefix)
+	cloudkitFinalizer                 string = fmt.Sprintf("%s/finalizer", cloudkitNamePrefix)
+	cloudkitManagementStateAnnotation string = fmt.Sprintf("%s/management-state", cloudkitNamePrefix)
 )
 
 func generateNamespaceName(instance *v1alpha1.ClusterOrder) string {


### PR DESCRIPTION
This is allows us to have the controller completely ignore a ClusterOrder
(management-state: unmanaged) or to never trigger a webhook for a
ClusterOrder (management-state: manual).
